### PR TITLE
Include the license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Include the license file in `sdist`s and other generated packages.