### PR TITLE
Added a trace back object to the cookies.bake() results instance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Installation
 
 It will automatically install `pytest`_ along with `cookiecutter`_.
 
-.. note:: This is a fork that adds an exeception trace back to the results
+.. note:: This is a fork that adds an exception trace back to the results
           of a cookies.bake() call. I needed this to help me debug.
 
 

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,7 @@ useful information:
 * ``exception``: is the exception that happened (if one did, ``None``
   otherwise)
 * ``project``: a `py.path.local`_ object pointing to the rendered project
-*  ``trace_back`` : a trace back object associated with the ``exception``
-  (if an exception happend, ``None`` otherwise)
+*  ``trace_back`` : a trace back object associated with the ``exception`` (if an exception happend, ``None`` otherwise)
 
 The returned ``LocalPath`` instance provides you with a powerful interface to
 filesystem related information, that comes in handy for validating the

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,6 @@ Installation
 
 It will automatically install `pytest`_ along with `cookiecutter`_.
 
-.. note:: This is a fork that adds an exception trace back to the results
-          of a cookies.bake() call. I needed this to help me debug.
-
-
 Features
 --------
 
@@ -38,7 +34,7 @@ useful information:
 * ``exception``: is the exception that happened (if one did, ``None``
   otherwise)
 * ``project``: a `py.path.local`_ object pointing to the rendered project
-*  ``trace_back`` : a trace back object associated with the ``exception`` (if an exception happend, ``None`` otherwise)
+*  ``trace_back`` : a trace back object associated with the ``exception`` (if an exception happened, ``None`` otherwise)
 
 The returned ``LocalPath`` instance provides you with a powerful interface to
 filesystem related information, that comes in handy for validating the

--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,6 @@ generated project layout and file contents:
     def test_readme(cookies):
         result = cookies.bake()
 
-      if result.trace_back:
-        print(result.trace_back_stack)
-
         readme_file = result.project.join('README.rst')
         readme_lines = readme_file.readlines(cr=False)
         assert readme_lines == ['helloworld', '==========']

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,10 @@ Installation
 
 It will automatically install `pytest`_ along with `cookiecutter`_.
 
+.. note:: This is a fork that adds an exeception trace back to the results
+          of a cookies.bake() call. I needed this to help me debug.
+
+
 Features
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,8 @@ useful information:
 * ``exception``: is the exception that happened (if one did, ``None``
   otherwise)
 * ``project``: a `py.path.local`_ object pointing to the rendered project
+*  ``trace_back`` : a trace back object associated with the ``exception``
+  (if an exception happend, ``None`` otherwise)
 
 The returned ``LocalPath`` instance provides you with a powerful interface to
 filesystem related information, that comes in handy for validating the
@@ -61,6 +63,9 @@ default values specified in ``cookiecutter.json``:
 
     def test_bake_project(cookies):
         result = cookies.bake(extra_context={'repo_name': 'helloworld'})
+
+        if result.exception:
+           print(result.trace_back_stack)
 
         assert result.exit_code == 0
         assert result.exception is None

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,9 @@ generated project layout and file contents:
     def test_readme(cookies):
         result = cookies.bake()
 
+      if result.trace_back:
+        print(result.trace_back_stack)
+
         readme_file = result.project.join('README.rst')
         readme_lines = readme_file.readlines(cr=False)
         assert readme_lines == ['helloworld', '==========']

--- a/README.rst
+++ b/README.rst
@@ -67,11 +67,12 @@ default values specified in ``cookiecutter.json``:
     def test_bake_project(cookies):
         result = cookies.bake(extra_context={'repo_name': 'helloworld'})
 
-        if result.exception:
+        if result.trace_back:
            print(result.trace_back_stack)
 
         assert result.exit_code == 0
         assert result.exception is None
+        assert result.trace_back is None
         assert result.project.basename == 'helloworld'
         assert result.project.isdir()
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,6 +6,18 @@ hold useful information:
 * ``exit_code``: is the exit code of cookiecutter, ``0`` means successful termination
 * ``exception``: is the exception that happened if one did
 * ``project``: a [py.path.local] object pointing to the rendered project
+* ``trace_back`` : a trace back object associated with the ``exception``
+  (if an exception happend, ``None`` otherwise)
+
+The result instance also has a helper property that will turn the trace_back
+object into a stack trace string:
+
+```python
+    result = cookies.bake()
+
+    if result.trace_back:
+        print(result.trace_back_stack)
+```
 
 The returned ``LocalPath`` instance provides you with a powerful interface
 to filesystem related information, that comes in handy for validating the generated

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -24,6 +24,7 @@ def test_bake_project(cookies):
 
     assert result.exit_code == 0
     assert result.exception is None
+    assert result.trace_back is None
     assert result.project.basename == 'helloworld'
     assert result.project.isdir()
 ```

--- a/pytest_cookies.py
+++ b/pytest_cookies.py
@@ -17,7 +17,8 @@ replay_dir: "{replay_dir}"
 class Result(object):
     """Holds the captured result of the cookiecutter project generation."""
 
-    def __init__(self, exception=None, exit_code=0, project_dir=None, trace_back=None):
+    def __init__(self, exception=None, exit_code=0, project_dir=None,
+                 trace_back=None):
         self.exception = exception
         self.exit_code = exit_code
         self._project_dir = project_dir

--- a/pytest_cookies.py
+++ b/pytest_cookies.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+import sys
+import traceback
 
 import py
 import pytest
+
 
 from cookiecutter.main import cookiecutter
 
@@ -14,16 +17,24 @@ replay_dir: "{replay_dir}"
 class Result(object):
     """Holds the captured result of the cookiecutter project generation."""
 
-    def __init__(self, exception=None, exit_code=0, project_dir=None):
+    def __init__(self, exception=None, exit_code=0, project_dir=None, trace_back=None):
         self.exception = exception
         self.exit_code = exit_code
         self._project_dir = project_dir
+        self.trace_back = trace_back
 
     @property
     def project(self):
         if self.exception is None:
             return py.path.local(self._project_dir)
         return None
+
+    @property
+    def trace_back_stack(self):
+        if self.trace_back:
+            return ''.join(traceback.format_tb(self.trace_back))
+        else:
+            return None
 
     def __repr__(self):
         return '<Result {}>'.format(
@@ -50,6 +61,7 @@ class Cookies(object):
         exception = None
         exit_code = 0
         project_dir = None
+        tb = None
 
         if template is None:
             template = self._default_template
@@ -66,11 +78,13 @@ class Cookies(object):
             if e.code != 0:
                 exception = e
             exit_code = e.code
+            tb = sys.exc_info()[2]
         except Exception as e:
             exception = e
             exit_code = -1
+            tb = sys.exc_info()[2]
 
-        return Result(exception, exit_code, project_dir)
+        return Result(exception, exit_code, project_dir, tb)
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -192,6 +192,7 @@ def test_cookies_bake_should_handle_exception(testdir):
             assert result.exit_code == -1
             assert result.exception is not None
             assert result.project is None
+            assert result.trace_back is not None
     """)
 
     result = testdir.runpytest('-v', '--template={}'.format(template))


### PR DESCRIPTION
I needed this to help me debug one of my tests. I have updated the documentation files, the exception test, as well as running my fork through tox on Travis with passing green across the board. Also added a helper property in the Result class that transforms the trace back object into a stack trace string.

The updated example in the README illustrates the update --

```python
def test_bake_project(cookies):
        result = cookies.bake(extra_context={'repo_name': 'helloworld'})
        if result.trace_back:
           print(result.trace_back_stack)

        assert result.exit_code == 0
        assert result.exception is None
        assert result.trace_back is None
        assert result.project.basename == 'helloworld'
        assert result.project.isdir()
```