### PR TITLE
Add new command line flag to keep generated projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ docs/_build/
 
 # PyBuilder
 target/
+.vscode
+.pytest_cache

--- a/README.rst
+++ b/README.rst
@@ -116,13 +116,13 @@ Keep Output Directories for Debugging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, the ``cookies`` fixture will remove all baked projects.
-However, you can pass the flag ``keep-cookies-directories`` if you'd like
+However, you can pass the flag ``keep-baked-projects`` if you'd like
 to keep them (`it won't clutter`_, pytest will remove entries older than 3
 temporary directories):
 
 .. code-block::
 
-    $ pytest --keep-cookies-directories
+    $ pytest --keep-baked-projects
 
 Issues
 ------

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,18 @@ To customize the `cookiecutter`_ template directory in a test,
         assert result.project.basename == 'example-project'
         assert result.project.isdir()
 
+Keep Output Directories for Debugging
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the ``cookies`` fixture will remove all baked projects.
+However, you can pass the flag ``keep-cookies-directories`` if you'd like
+to keep them (`it won't clutter`_, pytest will remove entries older than 3
+temporary directories):
+
+.. code-block::
+
+    $ pytest --keep-cookies-directories
+
 Issues
 ------
 
@@ -142,7 +154,7 @@ open source software.
    :alt: OSI certified
    :target: https://opensource.org/
 
-
+.. _`it won't clutter`: https://docs.pytest.org/en/latest/tmpdir.html#the-default-base-temporary-directory
 .. _`cookiecutter`: https://github.com/audreyr/cookiecutter
 .. _`@hackebrot`: https://github.com/hackebrot
 .. _`MIT`: http://opensource.org/licenses/MIT

--- a/pytest_cookies.py
+++ b/pytest_cookies.py
@@ -109,7 +109,7 @@ def cookies(request, tmpdir, _cookiecutter_config_file):
     yield Cookies(template_dir, output_factory, _cookiecutter_config_file)
 
     # Add option to keep generated output directories.
-    if not request.config.option.keep_cookies_directories:
+    if not request.config.option.keep_baked_projects:
         output_dir.remove()
 
 
@@ -125,9 +125,9 @@ def pytest_addoption(parser):
     )
 
     group.addoption(
-        '--keep-cookies-directories',
+        '--keep-baked-projects',
         action='store_true',
         default=False,
-        dest='keep_cookies_directories',
+        dest='keep_baked_projects',
         help="Keep projects directories generated with 'cookies.bake()'."
     )

--- a/pytest_cookies.py
+++ b/pytest_cookies.py
@@ -108,7 +108,9 @@ def cookies(request, tmpdir, _cookiecutter_config_file):
 
     yield Cookies(template_dir, output_factory, _cookiecutter_config_file)
 
-    output_dir.remove()
+    # Add option to keep generated output directories.
+    if not request.config.option.keep_cookies_directories:
+        output_dir.remove()
 
 
 def pytest_addoption(parser):
@@ -120,4 +122,12 @@ def pytest_addoption(parser):
         dest='template',
         help='specify the template to be rendered',
         type='string',
+    )
+
+    group.addoption(
+        '--keep-cookies-directories',
+        action='store_true',
+        default=False,
+        dest='keep_cookies_directories',
+        help="Keep projects directories generated with 'cookies.bake()'."
     )

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -194,8 +194,8 @@ def test_cookies_fixture_removes_output_directories(
     )
 
     result.stdout.fnmatch_lines([
-        '*::test_to_create_result PASSED',
-        '*::test_previously_generated_directory_is_removed PASSED',
+        '*::test_to_create_result PASSED*',
+        '*::test_previously_generated_directory_is_removed PASSED*',
     ])
 
 
@@ -227,8 +227,8 @@ def test_cookies_fixture_doesnt_remove_output_directories(
     )
 
     result.stdout.fnmatch_lines([
-        '*::test_to_create_result PASSED',
-        '*::test_previously_generated_directory_is_not_removed PASSED',
+        '*::test_to_create_result PASSED*',
+        '*::test_previously_generated_directory_is_not_removed PASSED*',
     ])
 
 

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -167,6 +167,71 @@ def test_cookies_bake_should_create_new_output_directories(
     ])
 
 
+def test_cookies_fixture_removes_output_directories(
+    testdir, cookiecutter_template
+):
+    """Programmatically create a **Cookiecutter** template and use `bake` to
+    create a project from it.
+    """
+    testdir.makepyfile("""
+        # -*- coding: utf-8 -*-
+        import os
+
+        def test_to_create_result(cookies):
+            global result_dirname
+            result = cookies.bake()
+            result_dirname = result.project.dirname
+            assert result.exception is None
+
+        def test_previously_generated_directory_is_removed(cookies):
+            exists = os.path.isdir(result_dirname)
+            assert exists is False
+    """)
+
+    result = testdir.runpytest(
+        '-v',
+        '--template={}'.format(cookiecutter_template)
+    )
+
+    result.stdout.fnmatch_lines([
+        '*::test_to_create_result PASSED',
+        '*::test_previously_generated_directory_is_removed PASSED',
+    ])
+
+
+def test_cookies_fixture_doesnt_remove_output_directories(
+    testdir, cookiecutter_template
+):
+    """Programmatically create a **Cookiecutter** template and use `bake` to
+    create a project from it.
+    """
+    testdir.makepyfile("""
+        # -*- coding: utf-8 -*-
+        import os
+
+        def test_to_create_result(cookies):
+            global result_dirname
+            result = cookies.bake()
+            result_dirname = result.project.dirname
+            assert result.exception is None
+
+        def test_previously_generated_directory_is_not_removed(cookies):
+            exists = os.path.isdir(result_dirname)
+            assert exists is True
+    """)
+
+    result = testdir.runpytest(
+        '-v',
+        '--template={}'.format(cookiecutter_template),
+        '--keep-cookies-directories'
+    )
+
+    result.stdout.fnmatch_lines([
+        '*::test_to_create_result PASSED',
+        '*::test_previously_generated_directory_is_not_removed PASSED',
+    ])
+
+
 def test_cookies_bake_should_handle_exception(testdir):
     """Programmatically create a **Cookiecutter** template and make sure that
     cookies.bake() handles exceptions that happen during project generation.

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -223,7 +223,7 @@ def test_cookies_fixture_doesnt_remove_output_directories(
     result = testdir.runpytest(
         '-v',
         '--template={}'.format(cookiecutter_template),
-        '--keep-cookies-directories'
+        '--keep-baked-projects'
     )
 
     result.stdout.fnmatch_lines([

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -22,7 +22,7 @@ def test_cookies_fixture(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        '*::test_valid_fixture PASSED',
+        '*::test_valid_fixture PASSED*',
     ])
 
     # make sure that that we get a '0' exit code for the testsuite
@@ -74,7 +74,7 @@ def test_cookies_bake_with_template_kwarg(testdir, cookiecutter_template):
     result = testdir.runpytest('-v')
 
     result.stdout.fnmatch_lines([
-        '*::test_bake_project PASSED',
+        '*::test_bake_project PASSED*',
     ])
 
 
@@ -106,7 +106,7 @@ def test_cookies_bake_template_kwarg_overrides_cli_option(
     result = testdir.runpytest('-v', '--template=foobar')
 
     result.stdout.fnmatch_lines([
-        '*::test_bake_project PASSED',
+        '*::test_bake_project PASSED*',
     ])
 
 
@@ -134,7 +134,7 @@ def test_cookies_bake(testdir, cookiecutter_template):
     )
 
     result.stdout.fnmatch_lines([
-        '*::test_bake_project PASSED',
+        '*::test_bake_project PASSED*',
     ])
 
 
@@ -163,7 +163,7 @@ def test_cookies_bake_should_create_new_output_directories(
     )
 
     result.stdout.fnmatch_lines([
-        '*::test_bake_should_create_new_output PASSED',
+        '*::test_bake_should_create_new_output PASSED*',
     ])
 
 
@@ -262,5 +262,5 @@ def test_cookies_bake_should_handle_exception(testdir):
     result = testdir.runpytest('-v', '--template={}'.format(template))
 
     result.stdout.fnmatch_lines([
-        '*::test_bake_should_fail PASSED',
+        '*::test_bake_should_fail PASSED*',
     ])

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -40,8 +40,8 @@ def test_config(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        '*::test_user_dir PASSED',
-        '*::test_valid_cookiecutter_config PASSED',
+        '*::test_user_dir PASSED*',
+        '*::test_valid_cookiecutter_config PASSED*',
     ])
 
     # make sure that that we get a '0' exit code for the testsuite


### PR DESCRIPTION
Sometimes is important to keep the baked projects in order to do some debugging. This commit add the feature, tests and documentation. The idea is that someone could do:

    pytest -k a_hard_to_debug_test --keep-cookies-directories

In this scenario, the tmp directories will not be removed and the user will be able to access them. This won't clutter the tmp directory because pytest will remove entries older than 3 temporary directories anyways, see:

https://docs.pytest.org/en/latest/tmpdir.html#the-default-base-temporary-directory