### PR TITLE
Drop python 33 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     include:
       - python: 2.7
         env: TOX_ENV=py27
-      - python: 3.3
-        env: TOX_ENV=py33
       - python: 3.4
         env: TOX_ENV=py34
       - python: 3.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Before you submit a pull request, check that it meets these guidelines:
    new functionality into a function with a docstring, and add the feature to
    the list in README.rst.
 
-3. The pull request should work for Python 2.7, 3.3, 3.4 and 3.5, and for PyPy.
+3. The pull request should work for Python 2.7, 3.4 and 3.5, and for PyPy.
    Check [travis pull requests][travis] and make sure that the tests pass for
    all supported Python versions.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,6 @@ environment:
     - PYTHON: "C:\\Python27-x64"
       TOX_ENV: "py27"
 
-    - PYTHON: "C:\\Python33-x64"
-      TOX_ENV: "py33"
-
     - PYTHON: "C:\\Python34-x64"
       TOX_ENV: "py34"
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=read('README.rst'),
     py_modules=['pytest_cookies'],
     install_requires=[
-        'pytest>=2.8.1',
+        'pytest>=3.3.0',
         'cookiecutter>=1.4.0'
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     description='A Pytest plugin for your Cookiecutter templates',
     long_description=read('README.rst'),
     py_modules=['pytest_cookies'],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=[
         'pytest>=3.3.0',
         'cookiecutter>=1.4.0'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,pypy,flake8
+envlist = py27,py34,py35,py36,pypy,flake8
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
[pytest 3.3.0](https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst#pytest-330-2017-11-23) dropped support for Python 3.3, so it's time to drop support here as well.

We should cut a new release after this is merged! 🚀 