### PR TITLE
Session scoped cookie-baking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     install_requires=[
         "arrow<0.14.0",
         "cookiecutter>=1.4.0,<=1.6.0",
-        "pytest>=3.3.0,<5.0.0",
+        "pytest>=3.3.0,<5.3.3",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Duplicate the `cookie` fixture as `cookies_session` to get a session-scoped fixture.  Not ideal, but not *that* terrible :)

This also adjusts the pytest pin to allow for pytest 5.x.  The new fixture didn't work with 4.x.