### PR TITLE
Move to pathlib.Path from py.path.local

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -8,30 +8,33 @@ jobs:
       fail-fast: false
       matrix:
         platform: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        environment: ["py35", "py36", "py37", "flake8"]
-        
+        environment: ["py36", "py37", "py38", "py39", "flake8", "pypy3"]
         include:
-          - environment: "py35"
-            python: "3.5"
-          - environment: "py36"
-            python: "3.6"
-          - environment: "py37"
-            python: "3.7"
-          - environment: "flake8"
-            python: "3.7"
+          - environment: py36
+            python: 3.6
+          - environment: py37
+            python: 3.7
+          - environment: py38
+            python: 3.8
+          - environment: py39
+            python: 3.9
+          - environment: flake8
+            python: 3.7
+          - environment: pypy3
+            python: pypy3
 
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install tox
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Run tox
-      run: |
-        tox -e ${{ matrix.environment }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Run tox
+        run: |
+          tox -e ${{ matrix.environment }}

--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -8,21 +8,21 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: "3.7"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install setuptools wheel twine
-    - name: Package project
-      run: |
-        python setup.py sdist bdist_wheel
-    - name: Upload distributions
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        twine upload dist/*
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools wheel twine
+      - name: Package project
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Upload distributions
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          twine upload dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
         env: TOXENV=py38
       - python: 3.9
         env: TOXENV=py39
-      - python: pypy
-        env: TOXENV=pypy
+      - python: pypy3
+        env: TOXENV=pypy3
       - python: 3.9
         env: TOXENV=flake8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,17 @@ cache:
 
 matrix:
     include:
-      - python: 2.7
-        env: TOXENV=py27
-      - python: 3.4
-        env: TOXENV=py34
-      - python: 3.5
-        env: TOXENV=py35
       - python: 3.6
         env: TOXENV=py36
       - python: 3.7
         env: TOXENV=py37
+      - python: 3.8
+        env: TOXENV=py38
+      - python: 3.9
+        env: TOXENV=py39
       - python: pypy
         env: TOXENV=pypy
-      - python: 3.7
+      - python: 3.9
         env: TOXENV=flake8
 
 install:

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -16,6 +16,7 @@
 - [@nedbat]
 - [@obestwalter]
 - [@pydanny]
+- [@jonzeolla]
 
 [@insspb]: https://github.com/insspb
 [@jakirkham]: https://github.com/jakirkham
@@ -25,3 +26,4 @@
 [@nedbat]: https://github.com/nedbat
 [@obestwalter]: https://github.com/obestwalter
 [@pydanny]: https://github.com/pydanny
+[@jonzeolla]: https://github.com/jonzeolla

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ development. Please note this documentation assumes you already have
     $ git clone https://github.com/YOUR-USERNAME/pytest-cookies
     ```
 
-3. Assuming you have virtualenv installed (If you have Python3.5 this should
+3. Assuming you have virtualenv installed (If you have Python3.6 this should
    already be there), you can create a new environment for your local
    development by typing:
 
@@ -145,7 +145,7 @@ Before you submit a pull request, check that it meets these guidelines:
    new functionality into a function with a docstring, and add the feature to
    the list in README.md.
 
-3. The pull request should work for Python 2.7, 3.4 and 3.5, and for PyPy.
+3. The pull request should work for Python 3.6, 3.7, 3.8, 3.9, and for PyPy.
    Check [travis pull requests][travis] and make sure that the tests pass for
    all supported Python versions.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ is free and open source software.
 [pip]: https://pypi.org/project/pip/
 [pypi]: https://pypi.org/project/pytest-cookies/
 [extra-context]: https://cookiecutter.readthedocs.io/en/latest/advanced/injecting_context.html
-[temporary-directories]: https://docs.pytest.org/en/latest/tmpdir.html#the-default-base-temporary-directory
+[temporary-directories]: https://docs.pytest.org/en/latest/reference/reference.html?highlight=tmp_path#tmp-path
 [tox]: https://pypi.org/project/tox/
 [new-issue]: https://github.com/hackebrot/pytest-cookies/issues
 [code-of-conduct]: https://github.com/hackebrot/pytest-cookies/blob/master/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ def test_bake_project(cookies):
 
     assert result.exit_code == 0
     assert result.exception is None
-    assert result.project.basename == "helloworld"
-    assert result.project.isdir()
+    assert result.project.name == "helloworld"
+    assert result.project.is_dir()
 ```
 
 The ``cookies.bake()`` method also accepts the ``extra_context`` keyword
@@ -56,16 +56,19 @@ pytest --template TEMPLATE
 ```
 
 You can customize the cookiecutter template directory from a test by passing
-in the optional ``template`` paramter:
+in the optional ``template`` parameter:
 
 ```python
 @pytest.fixture
-def custom_template(tmpdir):
-    template = tmpdir.ensure("cookiecutter-template", dir=True)
-    template.join("cookiecutter.json").write('{"repo_name": "example-project"}')
+def custom_template(tmp_path):
+    template = tmp_path.joinpath("cookiecutter-template")
+    template.mkdir(exist_ok=True)
 
-    repo_dir = template.ensure("{{cookiecutter.repo_name}}", dir=True)
-    repo_dir.join("README.rst").write("{{cookiecutter.repo_name}}")
+    template.joinpath("cookiecutter.json").write_text('{"repo_name": "example-project"}')
+
+    repo_dir = template.joinpath("{{cookiecutter.repo_name}}")
+    repo_dir.mkdir(exist_ok=True)
+    repo_dir.joinpath("README.rst").write_text("{{cookiecutter.repo_name}}")
 
     return template
 
@@ -76,8 +79,8 @@ def test_bake_custom_project(cookies, custom_template):
 
     assert result.exit_code == 0
     assert result.exception is None
-    assert result.project.basename == "example-project"
-    assert result.project.isdir()
+    assert result.project.name == "example-project"
+    assert result.project.is_dir()
 ```
 
 ## Keep output directories for debugging
@@ -114,7 +117,7 @@ abide by its terms.
 Distributed under the terms of the [MIT license][license], **pytest-cookies**
 is free and open source software.
 
-[cookiecutter]: https://github.com/audreyr/cookiecutter
+[cookiecutter]: https://github.com/cookiecutter/cookiecutter
 [pytest]: https://github.com/pytest-dev/pytest
 [pip]: https://pypi.org/project/pip/
 [pypi]: https://pypi.org/project/pytest-cookies/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Ubuntu2004
+
 environment:
   matrix:
   - TOXENV: py36

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,16 +2,16 @@ image: Ubuntu2004
 
 environment:
   matrix:
-  - TOXENV: py36
-  - TOXENV: py37
-  - TOXENV: py38
-  - TOXENV: py39
-  - TOXENV: pypy3
+    - TOXENV: py36
+    - TOXENV: py37
+    - TOXENV: py38
+    - TOXENV: py39
+    - TOXENV: pypy3
 
 build: off
 
 install:
-- pip install tox
+  - pip3 install tox
 
 test_script:
-- tox
+  - tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
   - TOXENV: py37
   - TOXENV: py38
   - TOXENV: py39
+  - TOXENV: pypy3
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Ubuntu2004
+image: Visual Studio 2019
 
 environment:
   matrix:
@@ -11,7 +11,7 @@ environment:
 build: off
 
 install:
-  - pip3 install tox
+  - pip install tox
 
 test_script:
   - tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,9 @@
 environment:
   matrix:
-  - TOXENV: py27
-  - TOXENV: py34
-  - TOXENV: py35
   - TOXENV: py36
   - TOXENV: py37
+  - TOXENV: py38
+  - TOXENV: py39
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
     - TOXENV: py37
     - TOXENV: py38
     - TOXENV: py39
-    - TOXENV: pypy3
 
 build: off
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,8 +18,8 @@ def test_readme(cookies):
     result = cookies.bake()
 
     readme_file = result.project.joinpath('README.rst')
-    readme_lines = readme_file.open(newline=None)
-    assert readme_lines == ['helloworld', '==========']
+    readme_lines = readme_file.read_text()
+    assert readme_lines == ['helloworld\n==========']
 ```
 
 [Path]: https://docs.python.org/3/library/pathlib.html#pathlib.Path

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,20 +5,21 @@ hold useful information:
 
 * ``exit_code``: is the exit code of cookiecutter, ``0`` means successful termination
 * ``exception``: is the exception that happened if one did
-* ``project``: a [py.path.local] object pointing to the rendered project
+* ``project``: a [Path] object pointing to the rendered project
 * ``context``: is the rendered context
 
-The returned ``LocalPath`` instance provides you with a powerful interface
-to filesystem related information, that comes in handy for validating the generated
-project layout and even file contents:
+The returned ``PosixPath`` or ``WindowsPath`` instance (depending on your OS)
+provides you with a powerful interface to filesystem related information that
+comes in handy for validating the generated project layout and even file
+contents:
 
 ```python
 def test_readme(cookies):
     result = cookies.bake()
 
-    readme_file = result.project.join('README.rst')
-    readme_lines = readme_file.readlines(cr=False)
+    readme_file = result.project.joinpath('README.rst')
+    readme_lines = readme_file.open(newline=None)
     assert readme_lines == ['helloworld', '==========']
 ```
 
-[py.path.local]: https://py.readthedocs.io/en/latest/path.html#py._path.local.LocalPath
+[Path]: https://docs.python.org/3/library/pathlib.html#pathlib.Path

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -24,8 +24,8 @@ def test_bake_project(cookies):
 
     assert result.exit_code == 0
     assert result.exception is None
-    assert result.project.basename == 'helloworld'
-    assert result.project.isdir()
+    assert result.project.name == 'helloworld'
+    assert result.project.is_dir()
 ```
 
 It accepts the ``extra_context`` keyword argument that will be

--- a/setup.py
+++ b/setup.py
@@ -31,22 +31,22 @@ setuptools.setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=3.4",
     install_requires=[
-        "arrow<0.14.0", "cookiecutter>=1.4.0,<1.8.0", "pytest>=3.3.0,<6.0.0"
+        "arrow<0.14.0", "cookiecutter>=1.4.0,<1.8.0", "pytest>=6.2.0,<7.0.0"
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python",
         "Topic :: Software Development :: Testing",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,9 @@ setuptools.setup(
     zip_safe=False,
     python_requires=">=3.6,<3.10",
     install_requires=[
-        "arrow<0.14.0", "cookiecutter>=1.4.0,<1.8.0", "pytest>=6.2.0,<7.0.0"
+        "arrow<0.14.0",
+        "cookiecutter>=1.4.0,<1.8.0",
+        "pytest>=6.2.0,<7.0.0",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.6,<3.10",
     install_requires=[
         "arrow<0.14.0", "cookiecutter>=1.4.0,<1.8.0", "pytest>=6.2.0,<7.0.0"
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[
         "arrow<0.14.0", "cookiecutter>=1.4.0,<1.8.0", "pytest>=6.2.0,<7.0.0"
     ],
@@ -41,7 +41,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.4",
+    python_requires=">=3.5",
     install_requires=[
         "arrow<0.14.0", "cookiecutter>=1.4.0,<1.8.0", "pytest>=6.2.0,<7.0.0"
     ],
@@ -41,7 +41,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/src/pytest_cookies/plugin.py
+++ b/src/pytest_cookies/plugin.py
@@ -130,7 +130,7 @@ def cookies(request, tmp_path, _cookiecutter_config_file):
 
     output_dir = tmp_path.joinpath("cookies")
     output_dir.mkdir()
-    output_factory = output_factory_closure(output_dir)
+    output_factory = _output_factory_closure(output_dir)
 
     yield Cookies(template_dir, output_factory, _cookiecutter_config_file)
 
@@ -153,7 +153,7 @@ def cookies_session(request, tmp_path_factory, _cookiecutter_config_file):
     template_dir = request.config.option.template
 
     output_dir = tmp_path_factory.mktemp(basename="cookies")
-    output_factory = output_factory_closure(output_dir)
+    output_factory = _output_factory_closure(output_dir)
 
     yield Cookies(template_dir, output_factory, _cookiecutter_config_file)
 
@@ -188,7 +188,7 @@ def pytest_configure(config):
     config.option.template = str(Path(config.option.template).absolute())
 
 
-def output_factory_closure(directory):
+def _output_factory_closure(directory):
     def output_factory(sub_dir):
         directory.joinpath(sub_dir).mkdir()
         return directory.joinpath(sub_dir)

--- a/src/pytest_cookies/plugin.py
+++ b/src/pytest_cookies/plugin.py
@@ -99,7 +99,7 @@ class Cookies(object):
 
 @pytest.fixture(scope="session")
 def _cookiecutter_config_file(tmp_path_factory):
-    user_dir = tmp_path_factory.mktemp("user_dir")
+    user_dir = tmp_path_factory.mktemp(basename="user_dir")
 
     cookiecutters_dir = user_dir.joinpath("cookiecutters")
     cookiecutters_dir.mkdir()
@@ -152,8 +152,7 @@ def cookies_session(request, tmp_path_factory, _cookiecutter_config_file):
     """
     template_dir = request.config.option.template
 
-    output_dir = tmp_path_factory.mktemp("cookies")
-    output_dir.mkdir()
+    output_dir = tmp_path_factory.mktemp(basename="cookies")
     output_factory = output_dir
 
     yield Cookies(template_dir, output_factory, _cookiecutter_config_file)

--- a/src/pytest_cookies/plugin.py
+++ b/src/pytest_cookies/plugin.py
@@ -2,7 +2,7 @@
 
 import os
 
-import py
+from pathlib import Path
 import pytest
 
 from cookiecutter.main import cookiecutter
@@ -27,7 +27,7 @@ class Result(object):
     @property
     def project(self):
         if self.exception is None:
-            return py.path.local(self._project_dir)
+            return Path(self._project_dir)
 
         return None
 
@@ -62,7 +62,7 @@ class Cookies(object):
         if template is None:
             template = self._default_template
 
-        context_file = py.path.local(template).join("cookiecutter.json")
+        context_file = Path(template).joinpath("cookiecutter.json")
 
         try:
             # Render the context, so that we can store it on the Result

--- a/src/pytest_cookies/plugin.py
+++ b/src/pytest_cookies/plugin.py
@@ -101,13 +101,15 @@ class Cookies(object):
 def _cookiecutter_config_file(tmp_path_factory):
     user_dir = tmp_path_factory.mktemp("user_dir")
 
-    cookiecutters_dir = user_dir.joinpath("cookiecutters").mkdir()
-    replay_dir = user_dir.joinpath("cookiecutter_replay").mkdir()
+    cookiecutters_dir = user_dir.joinpath("cookiecutters")
+    cookiecutters_dir.mkdir()
+    replay_dir = user_dir.joinpath("cookiecutter_replay")
+    replay_dir.mkdir()
 
     config_text = USER_CONFIG.format(
         cookiecutters_dir=cookiecutters_dir, replay_dir=replay_dir
     )
-    config_file = user_dir.join("config")
+    config_file = user_dir.joinpath("config")
 
     config_file.write_text(config_text, encoding="utf8")
     return config_file
@@ -126,14 +128,15 @@ def cookies(request, tmp_path, _cookiecutter_config_file):
     """
     template_dir = request.config.option.template
 
-    output_dir = tmp_path.joinpath("cookies").mkdir()
-    output_factory = output_dir.mkdir()
+    output_dir = tmp_path.joinpath("cookies")
+    output_dir.mkdir()
+    output_factory = output_dir
 
     yield Cookies(template_dir, output_factory, _cookiecutter_config_file)
 
     # Add option to keep generated output directories.
     if not request.config.option.keep_baked_projects:
-        output_dir.remove()
+        output_dir.rmdir()
 
 
 @pytest.fixture(scope="session")
@@ -150,13 +153,14 @@ def cookies_session(request, tmp_path_factory, _cookiecutter_config_file):
     template_dir = request.config.option.template
 
     output_dir = tmp_path_factory.mktemp("cookies")
-    output_factory = output_dir.mkdir()
+    output_dir.mkdir()
+    output_factory = output_dir
 
     yield Cookies(template_dir, output_factory, _cookiecutter_config_file)
 
     # Add option to keep generated output directories.
     if not request.config.option.keep_baked_projects:
-        output_dir.remove()
+        output_dir.rmdir()
 
 
 def pytest_addoption(parser):

--- a/src/pytest_cookies/plugin.py
+++ b/src/pytest_cookies/plugin.py
@@ -98,11 +98,11 @@ class Cookies(object):
 
 
 @pytest.fixture(scope="session")
-def _cookiecutter_config_file(tmpdir_factory):
-    user_dir = tmpdir_factory.mktemp("user_dir")
+def _cookiecutter_config_file(tmp_path_factory):
+    user_dir = tmp_path_factory.mktemp("user_dir")
 
-    cookiecutters_dir = user_dir.mkdir("cookiecutters")
-    replay_dir = user_dir.mkdir("cookiecutter_replay")
+    cookiecutters_dir = user_dir.joinpath("cookiecutters").mkdir()
+    replay_dir = user_dir.joinpath("cookiecutter_replay").mkdir()
 
     config_text = USER_CONFIG.format(
         cookiecutters_dir=cookiecutters_dir, replay_dir=replay_dir
@@ -114,7 +114,7 @@ def _cookiecutter_config_file(tmpdir_factory):
 
 
 @pytest.fixture
-def cookies(request, tmpdir, _cookiecutter_config_file):
+def cookies(request, tmp_path, _cookiecutter_config_file):
     """Yield an instance of the Cookies helper class that can be used to
     generate a project from a template.
 
@@ -126,8 +126,8 @@ def cookies(request, tmpdir, _cookiecutter_config_file):
     """
     template_dir = request.config.option.template
 
-    output_dir = tmpdir.mkdir("cookies")
-    output_factory = output_dir.mkdir
+    output_dir = tmp_path.joinpath("cookies").mkdir()
+    output_factory = output_dir.mkdir()
 
     yield Cookies(template_dir, output_factory, _cookiecutter_config_file)
 
@@ -137,7 +137,7 @@ def cookies(request, tmpdir, _cookiecutter_config_file):
 
 
 @pytest.fixture(scope="session")
-def cookies_session(request, tmpdir_factory, _cookiecutter_config_file):
+def cookies_session(request, tmp_path_factory, _cookiecutter_config_file):
     """Yield an instance of the Cookies helper class that can be used to
     generate a project from a template.
 
@@ -149,8 +149,8 @@ def cookies_session(request, tmpdir_factory, _cookiecutter_config_file):
     """
     template_dir = request.config.option.template
 
-    output_dir = tmpdir_factory.mktemp("cookies")
-    output_factory = output_dir.mkdir
+    output_dir = tmp_path_factory.mktemp("cookies")
+    output_factory = output_dir.mkdir()
 
     yield Cookies(template_dir, output_factory, _cookiecutter_config_file)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,9 @@ pytest_plugins = "pytester"
 
 @pytest.fixture(name="cookiecutter_template")
 def fixture_cookiecutter_template(tmp_path):
-    template = tmp_path
+    """cookiecutter template fixture"""
+    template = tmp_path.joinpath("cookiecutter-template")
+    template.mkdir(exist_ok=True)
 
     template_config = collections.OrderedDict(
         [("repo_name", "foobar"), ("short_description", "Test Project")]
@@ -26,7 +28,6 @@ def fixture_cookiecutter_template(tmp_path):
     )
 
     template.joinpath("{{cookiecutter.repo_name}}").mkdir(exist_ok=True)
-
     template.joinpath("README.rst").write_text(template_readme)
 
     return template

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,13 @@ pytest_plugins = "pytester"
 
 
 @pytest.fixture(name="cookiecutter_template")
-def fixture_cookiecutter_template(tmpdir):
-    template = tmpdir.ensure("cookiecutter-template", dir=True)
+def fixture_cookiecutter_template(tmp_path):
+    template = tmp_path
 
     template_config = collections.OrderedDict(
         [("repo_name", "foobar"), ("short_description", "Test Project")]
     )
-    template.join("cookiecutter.json").write(json.dumps(template_config))
+    template.joinpath("cookiecutter.json").write_text(json.dumps(template_config))
 
     template_readme = "\n".join(
         [
@@ -25,7 +25,8 @@ def fixture_cookiecutter_template(tmpdir):
         ]
     )
 
-    repo = template.ensure("{{cookiecutter.repo_name}}", dir=True)
-    repo.join("README.rst").write(template_readme)
+    template.joinpath("{{cookiecutter.repo_name}}").mkdir(exist_ok=True)
+
+    template.joinpath("README.rst").write_text(template_readme)
 
     return template

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -218,13 +218,13 @@ def test_cookies_fixture_removes_output_directories(pytester, cookiecutter_templ
         from pathlib import Path
 
         def test_to_create_result(cookies):
-            global result_parent
+            global result_path
             result = cookies.bake()
-            result_parent = result.project.parent
+            result_path = result.project
             assert result.exception is None
 
         def test_previously_generated_directory_is_removed(cookies):
-            exists = Path.is_dir(result_parent)
+            exists = result_path.is_dir()
             assert exists is False
     """
     )
@@ -251,13 +251,13 @@ def test_cookies_fixture_doesnt_remove_output_directories(
         from pathlib import Path
 
         def test_to_create_result(cookies):
-            global result_parent
+            global result_path
             result = cookies.bake()
-            result_parent = result.project.parent
+            result_path = result.project
             assert result.exception is None
 
         def test_previously_generated_directory_is_not_removed(cookies):
-            exists = Path.is_dir(result_parent)
+            exists = result_path.is_dir()
             assert exists is True
     """
     )
@@ -334,7 +334,6 @@ def test_cookies_bake_choices(pytester, choice):
             assert result.project.name == 'docs'
             assert result.project.is_dir()
 
-            print(result.project)
             assert result.project.joinpath('README.rst').read_text() == 'docs_tool: %s'
 
             assert str(result) == '<Result {}>'.format(result.project)

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -6,7 +6,6 @@ import pytest
 
 def test_cookies_fixture(pytester):
     """Make sure that pytest accepts the `cookies` fixture."""
-
     # create a temporary pytest test module
     pytester.makepyfile(
         """
@@ -60,7 +59,6 @@ def test_cookies_bake_template_kwarg_overrides_cli_option(
     pytester, cookiecutter_template
 ):
     """bake template kwarg overrides cli option."""
-
     pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
@@ -119,7 +117,6 @@ def test_cookies_bake_result_context(pytester, cookiecutter_template):
 
     Check that the result holds the rendered context.
     """
-
     pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
@@ -158,7 +155,6 @@ def test_cookies_bake_result_context_exception(pytester, cookiecutter_template):
     Check that exceptions resulting from rendering the context are stored on
     result and that the rendered context is not set.
     """
-
     pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
@@ -284,12 +280,11 @@ def test_cookies_bake_should_handle_exception(pytester):
 
     We expect **Cookiecutter** to raise a `NonTemplatedInputDirException`.
     """
-    template = pytester.path
+    template = pytester.path.joinpath("cookiecutter-fail")
+    template.mkdir(exist_ok=True)
 
     template_config = {"repo_name": "foobar", "short_description": "Test Project"}
     template.joinpath("cookiecutter.json").write_text(json.dumps(template_config))
-
-    template.joinpath("cookiecutter.repo_name").mkdir(exist_ok=True)
 
     pytester.makepyfile(
         """
@@ -314,13 +309,14 @@ def test_cookies_bake_choices(pytester, choice):
     """Programmatically create a **Cookiecutter** template and make sure that
     cookies.bake() works with choice variables.
     """
-    path = pytester.path
-    path.joinpath("cookiecutter-choices").mkdir(exist_ok=True)
-    template = path.joinpath("cookiecutter-choices")
+    template = pytester.path.joinpath("cookiecutter-choices")
+    template.mkdir(exist_ok=True)
+
     template_config = {"repo_name": "docs", "docs_tool": ["mkdocs", "sphinx", "none"]}
     template.joinpath("cookiecutter.json").write_text(json.dumps(template_config))
-    template.joinpath("{{cookiecutter.repo_name}}").mkdir(exist_ok=True)
+
     repo = template.joinpath("{{cookiecutter.repo_name}}")
+    repo.mkdir(exist_ok=True)
     repo.joinpath("README.rst").write_text("docs_tool: {{cookiecutter.docs_tool}}")
 
     pytester.makepyfile(

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -3,12 +3,11 @@
 import json
 import pytest
 
-
-def test_cookies_fixture(testdir):
+def test_cookies_fixture(pytester):
     """Make sure that pytest accepts the `cookies` fixture."""
 
     # create a temporary pytest test module
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
@@ -19,7 +18,7 @@ def test_cookies_fixture(testdir):
     )
 
     # run pytest with the following cmd args
-    result = testdir.runpytest("-v")
+    result = pytester.runpytest("-v")
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(["*::test_valid_fixture PASSED*"])
@@ -28,9 +27,9 @@ def test_cookies_fixture(testdir):
     assert result.ret == 0
 
 
-def test_cookies_bake_with_template_kwarg(testdir, cookiecutter_template):
+def test_cookies_bake_with_template_kwarg(pytester, cookiecutter_template):
     """bake accepts a template kwarg."""
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
@@ -42,8 +41,8 @@ def test_cookies_bake_with_template_kwarg(testdir, cookiecutter_template):
 
             assert result.exit_code == 0
             assert result.exception is None
-            assert result.project.basename == 'helloworld'
-            assert result.project.isdir()
+            assert result.project.name == 'helloworld'
+            assert result.project.is_dir()
 
             assert str(result) == '<Result {}>'.format(result.project)
     """
@@ -51,17 +50,17 @@ def test_cookies_bake_with_template_kwarg(testdir, cookiecutter_template):
     )
 
     # run pytest without the template cli arg
-    result = testdir.runpytest("-v")
+    result = pytester.runpytest("-v")
 
     result.stdout.fnmatch_lines(["*::test_bake_project PASSED*"])
 
 
 def test_cookies_bake_template_kwarg_overrides_cli_option(
-    testdir, cookiecutter_template
+    pytester, cookiecutter_template
 ):
     """bake template kwarg overrides cli option."""
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
@@ -73,8 +72,8 @@ def test_cookies_bake_template_kwarg_overrides_cli_option(
 
             assert result.exit_code == 0
             assert result.exception is None
-            assert result.project.basename == 'helloworld'
-            assert result.project.isdir()
+            assert result.project.name == 'helloworld'
+            assert result.project.is_dir()
 
             assert str(result) == '<Result {}>'.format(result.project)
     """
@@ -83,16 +82,16 @@ def test_cookies_bake_template_kwarg_overrides_cli_option(
 
     # run pytest with a bogus template name
     # it should use template directory passed to `cookies.bake`
-    result = testdir.runpytest("-v", "--template=foobar")
+    result = pytester.runpytest("-v", "--template=foobar")
 
     result.stdout.fnmatch_lines(["*::test_bake_project PASSED*"])
 
 
-def test_cookies_bake(testdir, cookiecutter_template):
+def test_cookies_bake(pytester, cookiecutter_template):
     """Programmatically create a **Cookiecutter** template and use `bake` to
     create a project from it.
     """
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
@@ -101,26 +100,26 @@ def test_cookies_bake(testdir, cookiecutter_template):
 
             assert result.exit_code == 0
             assert result.exception is None
-            assert result.project.basename == 'helloworld'
-            assert result.project.isdir()
+            assert result.project.name == 'helloworld'
+            assert result.project.is_dir()
 
             assert str(result) == '<Result {}>'.format(result.project)
     """
     )
 
-    result = testdir.runpytest("-v", "--template={}".format(cookiecutter_template))
+    result = pytester.runpytest("-v", "--template={}".format(cookiecutter_template))
 
     result.stdout.fnmatch_lines(["*::test_bake_project PASSED*"])
 
 
-def test_cookies_bake_result_context(testdir, cookiecutter_template):
+def test_cookies_bake_result_context(pytester, cookiecutter_template):
     """Programmatically create a **Cookiecutter** template and use `bake` to
     create a project from it.
 
     Check that the result holds the rendered context.
     """
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
@@ -134,8 +133,8 @@ def test_cookies_bake_result_context(testdir, cookiecutter_template):
 
             assert result.exit_code == 0
             assert result.exception is None
-            assert result.project.basename == 'cookies'
-            assert result.project.isdir()
+            assert result.project.name == 'cookies'
+            assert result.project.is_dir()
 
             assert result.context == {
                 'repo_name': 'cookies',
@@ -146,12 +145,12 @@ def test_cookies_bake_result_context(testdir, cookiecutter_template):
     """
     )
 
-    result = testdir.runpytest("-v", "--template={}".format(cookiecutter_template))
+    result = pytester.runpytest("-v", "--template={}".format(cookiecutter_template))
 
     result.stdout.fnmatch_lines(["*::test_bake_project PASSED*"])
 
 
-def test_cookies_bake_result_context_exception(testdir, cookiecutter_template):
+def test_cookies_bake_result_context_exception(pytester, cookiecutter_template):
     """Programmatically create a **Cookiecutter** template and use `bake` to
     create a project from it.
 
@@ -159,7 +158,7 @@ def test_cookies_bake_result_context_exception(testdir, cookiecutter_template):
     result and that the rendered context is not set.
     """
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
@@ -181,59 +180,59 @@ def test_cookies_bake_result_context_exception(testdir, cookiecutter_template):
     """
     )
 
-    result = testdir.runpytest("-v", "--template={}".format(cookiecutter_template))
+    result = pytester.runpytest("-v", "--template={}".format(cookiecutter_template))
 
     result.stdout.fnmatch_lines(["*::test_bake_project PASSED*"])
 
 
 def test_cookies_bake_should_create_new_output_directories(
-    testdir, cookiecutter_template
+    pytester, cookiecutter_template
 ):
     """Programmatically create a **Cookiecutter** template and use `bake` to
     create a project from it.
     """
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
         def test_bake_should_create_new_output(cookies):
             first_result = cookies.bake()
             assert first_result.exception is None
-            assert first_result.project.dirname.endswith('bake00')
+            assert str(first_result.project.parent).endswith('bake00')
 
             second_result = cookies.bake()
             assert second_result.exception is None
-            assert second_result.project.dirname.endswith('bake01')
+            assert str(second_result.project.parent).endswith('bake01')
     """
     )
 
-    result = testdir.runpytest("-v", "--template={}".format(cookiecutter_template))
+    result = pytester.runpytest("-v", "--template={}".format(cookiecutter_template))
 
     result.stdout.fnmatch_lines(["*::test_bake_should_create_new_output PASSED*"])
 
 
-def test_cookies_fixture_removes_output_directories(testdir, cookiecutter_template):
+def test_cookies_fixture_removes_output_directories(pytester, cookiecutter_template):
     """Programmatically create a **Cookiecutter** template and use `bake` to
     create a project from it.
     """
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
-        import os
+        from pathlib import Path
 
         def test_to_create_result(cookies):
-            global result_dirname
+            global result_parent
             result = cookies.bake()
-            result_dirname = result.project.dirname
+            result_parent = result.project.parent
             assert result.exception is None
 
         def test_previously_generated_directory_is_removed(cookies):
-            exists = os.path.isdir(result_dirname)
+            exists = Path.is_dir(result_parent)
             assert exists is False
     """
     )
 
-    result = testdir.runpytest("-v", "--template={}".format(cookiecutter_template))
+    result = pytester.runpytest("-v", "--template={}".format(cookiecutter_template))
 
     result.stdout.fnmatch_lines(
         [
@@ -244,29 +243,29 @@ def test_cookies_fixture_removes_output_directories(testdir, cookiecutter_templa
 
 
 def test_cookies_fixture_doesnt_remove_output_directories(
-    testdir, cookiecutter_template
+    pytester, cookiecutter_template
 ):
     """Programmatically create a **Cookiecutter** template and use `bake` to
     create a project from it.
     """
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
-        import os
+        from pathlib import Path
 
         def test_to_create_result(cookies):
-            global result_dirname
+            global result_parent
             result = cookies.bake()
-            result_dirname = result.project.dirname
+            result_parent = result.project.parent
             assert result.exception is None
 
         def test_previously_generated_directory_is_not_removed(cookies):
-            exists = os.path.isdir(result_dirname)
+            exists = Path.is_dir(result_parent)
             assert exists is True
     """
     )
 
-    result = testdir.runpytest(
+    result = pytester.runpytest(
         "-v", "--template={}".format(cookiecutter_template), "--keep-baked-projects"
     )
 
@@ -278,20 +277,20 @@ def test_cookies_fixture_doesnt_remove_output_directories(
     )
 
 
-def test_cookies_bake_should_handle_exception(testdir):
+def test_cookies_bake_should_handle_exception(pytester):
     """Programmatically create a **Cookiecutter** template and make sure that
     cookies.bake() handles exceptions that happen during project generation.
 
     We expect **Cookiecutter** to raise a `NonTemplatedInputDirException`.
     """
-    template = testdir.tmpdir.ensure("cookiecutter-fail", dir=True)
+    template = pytester.path
 
     template_config = {"repo_name": "foobar", "short_description": "Test Project"}
-    template.join("cookiecutter.json").write(json.dumps(template_config))
+    template.joinpath("cookiecutter.json").write_text(json.dumps(template_config))
 
-    template.ensure("cookiecutter.repo_name", dir=True)
+    template.joinpath("cookiecutter.repo_name").mkdir(exist_ok=True)
 
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
@@ -304,24 +303,26 @@ def test_cookies_bake_should_handle_exception(testdir):
     """
     )
 
-    result = testdir.runpytest("-v", "--template={}".format(template))
+    result = pytester.runpytest("-v", "--template={}".format(template))
 
     result.stdout.fnmatch_lines(["*::test_bake_should_fail PASSED*"])
 
 
 @pytest.mark.parametrize("choice", ["mkdocs", "sphinx", "none"])
-def test_cookies_bake_choices(testdir, choice):
+def test_cookies_bake_choices(pytester, choice):
     """Programmatically create a **Cookiecutter** template and make sure that
     cookies.bake() works with choice variables.
     """
-    template = testdir.tmpdir.ensure("cookiecutter-choices", dir=True)
+    path = pytester.path
+    path.joinpath("cookiecutter-choices").mkdir(exist_ok=True)
+    template = path.joinpath("cookiecutter-choices")
     template_config = {"repo_name": "docs", "docs_tool": ["mkdocs", "sphinx", "none"]}
-    template.join("cookiecutter.json").write(json.dumps(template_config))
+    template.joinpath("cookiecutter.json").write_text(json.dumps(template_config))
+    template.joinpath("{{cookiecutter.repo_name}}").mkdir(exist_ok=True)
+    repo = template.joinpath("{{cookiecutter.repo_name}}")
+    repo.joinpath("README.rst").write_text("docs_tool: {{cookiecutter.docs_tool}}")
 
-    repo = template.ensure("{{cookiecutter.repo_name}}", dir=True)
-    repo.join("README.rst").write("docs_tool: {{cookiecutter.docs_tool}}")
-
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
@@ -333,10 +334,11 @@ def test_cookies_bake_choices(testdir, choice):
 
             assert result.exit_code == 0
             assert result.exception is None
-            assert result.project.basename == 'docs'
-            assert result.project.isdir()
+            assert result.project.name == 'docs'
+            assert result.project.is_dir()
 
-            assert result.project.join('README.rst').read() == 'docs_tool: %s'
+            print(result.project)
+            assert result.project.joinpath('README.rst').read_text() == 'docs_tool: %s'
 
             assert str(result) == '<Result {}>'.format(result.project)
     """
@@ -344,8 +346,8 @@ def test_cookies_bake_choices(testdir, choice):
     )
 
     # run pytest without the template cli arg
-    result = testdir.runpytest("-v")
+    result = pytester.runpytest("-v")
 
     result.stdout.fnmatch_lines(["*::test_bake_project PASSED*"])
 
-    result = testdir.runpytest("-v", "--template={}".format(template))
+    result = pytester.runpytest("-v", "--template={}".format(template))

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -3,6 +3,7 @@
 import json
 import pytest
 
+
 def test_cookies_fixture(pytester):
     """Make sure that pytest accepts the `cookies` fixture."""
 

--- a/tests/test_help_message.py
+++ b/tests/test_help_message.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-def test_cookies_group(testdir):
-    result = testdir.runpytest("--help")
+def test_cookies_group(pytester):
+    result = pytester.runpytest("--help")
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(["cookies:", "*--template=TEMPLATE*"])

--- a/tests/test_help_message.py
+++ b/tests/test_help_message.py
@@ -2,6 +2,8 @@
 
 
 def test_cookies_group(pytester):
+    """Test the help message"""
     result = pytester.runpytest("--help")
+
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(["cookies:", "*--template=TEMPLATE*"])

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -9,28 +9,29 @@ def test_config(pytester):
         # -*- coding: utf-8 -*-
 
         import poyo
+        import re
 
 
         def test_user_dir(tmp_path_factory, _cookiecutter_config_file):
             basetemp = tmp_path_factory.getbasetemp()
 
-            assert _cookiecutter_config_file.basename == 'config'
+            assert _cookiecutter_config_file.absolute().name == 'config'
 
-            user_dir = _cookiecutter_config_file.dirpath()
-            assert user_dir.fnmatch('user_dir?')
+            user_dir = _cookiecutter_config_file.absolute().parent
+            assert re.match('user_dir?', user_dir.name)
 
-            assert user_dir.dirpath() == basetemp
+            assert user_dir.parent == basetemp
 
 
         def test_valid_cookiecutter_config(_cookiecutter_config_file):
-            config_text = _cookiecutter_config_file.read()
+            config_text = _cookiecutter_config_file.read_text()
             config = poyo.parse_string(config_text)
 
-            user_dir = _cookiecutter_config_file.dirpath()
+            user_dir = _cookiecutter_config_file.parent
 
             expected = {
-                'cookiecutters_dir': str(user_dir.join('cookiecutters')),
-                'replay_dir': str(user_dir.join('cookiecutter_replay')),
+                'cookiecutters_dir': str(user_dir.joinpath('cookiecutters')),
+                'replay_dir': str(user_dir.joinpath('cookiecutter_replay')),
             }
             assert config == expected
     """

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -15,9 +15,9 @@ def test_config(pytester):
         def test_user_dir(tmp_path_factory, _cookiecutter_config_file):
             basetemp = tmp_path_factory.getbasetemp()
 
-            assert _cookiecutter_config_file.absolute().name == 'config'
+            assert _cookiecutter_config_file.name == 'config'
 
-            user_dir = _cookiecutter_config_file.absolute().parent
+            user_dir = _cookiecutter_config_file.parent
             assert re.match('user_dir?', user_dir.name)
 
             assert user_dir.parent == basetemp

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 
-def test_config(testdir):
+def test_config(pytester):
     """Make sure that pytest accepts the `cookies` fixture."""
 
     # create a temporary pytest test module
-    testdir.makepyfile(
+    pytester.makepyfile(
         """
         # -*- coding: utf-8 -*-
 
@@ -38,7 +38,7 @@ def test_config(testdir):
     )
 
     # run pytest with the following cmd args
-    result = testdir.runpytest("-v")
+    result = pytester.runpytest("-v")
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines(

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -11,8 +11,8 @@ def test_config(pytester):
         import poyo
 
 
-        def test_user_dir(tmpdir_factory, _cookiecutter_config_file):
-            basetemp = tmpdir_factory.getbasetemp()
+        def test_user_dir(tmp_path_factory, _cookiecutter_config_file):
+            basetemp = tmp_path_factory.getbasetemp()
 
             assert _cookiecutter_config_file.basename == 'config'
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -3,7 +3,6 @@
 
 def test_config(pytester):
     """Make sure that pytest accepts the `cookies` fixture."""
-
     # create a temporary pytest test module
     pytester.makepyfile(
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37,py38,py39,flake8
+envlist = py35,py36,py37,py38,py39,flake8
 
 [testenv]
 download = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,flake8
+envlist = py34,py35,py36,py37,py38,py39,flake8
 
 [testenv]
 download = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,flake8
+envlist = py36,py37,py38,py39,flake8,pypy3
 
 [testenv]
 download = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,flake8
+envlist = py36,py37,py38,py39,flake8
 
 [testenv]
 download = true


### PR DESCRIPTION
This is a breaking change that removes support for versions of python and pypy which are not supported (similar to https://github.com/hackebrot/pytest-cookies/pull/23#issue-192251019).

It also has some breaking changes to move to pathlib.Path (a standard library), and away from py (third party project and not recommended for new code).

I would suggest a version bump from 0.5.1 to 0.6.0

Sorry for the noise - just getting familiar with this repo.