### PR TITLE
fix: Replace `"` with `'` in user config template

### DIFF
--- a/src/pytest_cookies/plugin.py
+++ b/src/pytest_cookies/plugin.py
@@ -11,8 +11,8 @@ from cookiecutter.main import cookiecutter
 from cookiecutter.prompt import prompt_for_config
 
 USER_CONFIG = u"""
-cookiecutters_dir: "{cookiecutters_dir}"
-replay_dir: "{replay_dir}"
+cookiecutters_dir: '{cookiecutters_dir}'
+replay_dir: '{replay_dir}'
 """
 
 


### PR DESCRIPTION
After `cookiecutter` has [moved](https://github.com/cookiecutter/cookiecutter/pull/1489) from `poyo` to `pyyaml`, tests on windows broke due to `pyyaml` handling `"` as a start of escaped unicode string. Present PR addresses this issue by replacing the `"` with `'`, which do not imply escaping.