### PR TITLE
Fixes for cookiecutter 2.1.0, especially PyYAML

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        environment: ["py37", "py38", "py39", "py310", "flake8"]
+        environment: ["py37", "py38", "py39", "py310", "py311", "flake8"]
 
         include:
           - environment: "py37"

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -17,7 +17,7 @@ jobs:
             python: "3.8"
           - environment: "py39"
             python: "3.9"
-          - environment: "py10"
+          - environment: "py310"
             python: "3.10"
           - environment: "flake8"
             python: "3.7"

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -19,6 +19,8 @@ jobs:
             python: "3.9"
           - environment: "py310"
             python: "3.10"
+          - environment: "py311"
+            python: "3.11"
           - environment: "flake8"
             python: "3.7"
 

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -8,17 +8,17 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        environment: ["py36", "py37", "py38", "py39", "flake8"]
+        environment: ["py37", "py38", "py39", "py310", "flake8"]
 
         include:
-          - environment: "py36"
-            python: "3.6"
           - environment: "py37"
             python: "3.7"
           - environment: "py38"
             python: "3.8"
           - environment: "py39"
             python: "3.9"
+          - environment: "py10"
+            python: "3.10"
           - environment: "flake8"
             python: "3.7"
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python",
         "Topic :: Software Development :: Testing",

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,9 @@ setuptools.setup(
     zip_safe=False,
     python_requires=">=3.7",
     install_requires=[
-        "cookiecutter>=2.0.1",
-        "pytest>=3.9.0",
+        "cookiecutter>=1.4.0",
+        "pytest>=3.9.0",  # adds tmp_path fixtures
+        "pyyaml>=5.3.1",  # matches cookiecutter 2.1.0
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setuptools.setup(
     name="pytest-cookies",
-    version="0.6.1",
+    version="0.7.0",
     author="Raphael Pierzina",
     author_email="raphael@hackebrot.de",
     maintainer="Raphael Pierzina",
@@ -31,10 +31,10 @@ setuptools.setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
-        "cookiecutter>=1.4.0",
-        "pytest>=3.3.0",
+        "cookiecutter>=2.0.1",
+        "pytest>=3.9.0",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -42,10 +42,10 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python",
         "Topic :: Software Development :: Testing",

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,8 @@ setuptools.setup(
     zip_safe=False,
     python_requires=">=3.7",
     install_requires=[
-        "cookiecutter>=1.4.0",
+        "cookiecutter>=2.1.0",
         "pytest>=3.9.0",  # adds tmp_path fixtures
-        "pyyaml>=5.3.1",  # matches cookiecutter 2.1.0
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
     zip_safe=False,
     python_requires=">=3.7",
     install_requires=[
-        "cookiecutter>=2.1.0",
+        "cookiecutter>=2.1.0",  # uses pyyaml
         "pytest>=3.9.0",  # adds tmp_path fixtures
     ],
     classifiers=[

--- a/src/pytest_cookies/plugin.py
+++ b/src/pytest_cookies/plugin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import json
 import os
 import pathlib
 import warnings
@@ -9,11 +10,6 @@ import pytest
 from cookiecutter.generate import generate_context
 from cookiecutter.main import cookiecutter
 from cookiecutter.prompt import prompt_for_config
-
-USER_CONFIG = u"""
-cookiecutters_dir: "{cookiecutters_dir}"
-replay_dir: "{replay_dir}"
-"""
 
 
 class Result(object):
@@ -122,16 +118,17 @@ class Cookies(object):
 @pytest.fixture(scope="session")
 def _cookiecutter_config_file(tmpdir_factory):
     user_dir = tmpdir_factory.mktemp("user_dir")
-
-    cookiecutters_dir = user_dir.mkdir("cookiecutters")
-    replay_dir = user_dir.mkdir("cookiecutter_replay")
-
-    config_text = USER_CONFIG.format(
-        cookiecutters_dir=cookiecutters_dir, replay_dir=replay_dir
-    )
     config_file = user_dir.join("config")
 
-    config_file.write_text(config_text, encoding="utf8")
+    config = {
+        "cookiecutters_dir": str(user_dir.mkdir("cookiecutters")),
+        "replay_dir": str(user_dir.mkdir("cookiecutter_replay")),
+    }
+
+    # Note that the file is expected to be YAML, but JSON is a subset of YAML
+    with config_file.open("w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+
     return config_file
 
 

--- a/src/pytest_cookies/plugin.py
+++ b/src/pytest_cookies/plugin.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import json
 import os
 import pathlib
 import warnings
 
 import py
 import pytest
+import yaml
+
 from cookiecutter.generate import generate_context
 from cookiecutter.main import cookiecutter
 from cookiecutter.prompt import prompt_for_config
@@ -125,9 +126,8 @@ def _cookiecutter_config_file(tmpdir_factory):
         "replay_dir": str(user_dir.mkdir("cookiecutter_replay")),
     }
 
-    # Note that the file is expected to be YAML, but JSON is a subset of YAML
     with config_file.open("w", encoding="utf-8") as f:
-        json.dump(config, f, indent=2)
+        yaml.dump(config, f, Dumper=yaml.Dumper)
 
     return config_file
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -24,7 +24,7 @@ def test_config(testdir):
 
 
         def test_valid_cookiecutter_config(_cookiecutter_config_file):
-            with open(_cookiecutter_config_file) as f:            
+            with open(_cookiecutter_config_file) as f:         
                 config = yaml.load(f, Loader=yaml.Loader)
 
             user_dir = _cookiecutter_config_file.dirpath()

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -25,7 +25,7 @@ def test_config(testdir):
 
         def test_valid_cookiecutter_config(_cookiecutter_config_file):
             with open(_cookiecutter_config_file) as f:            
-                config = yaml.load(f)
+                config = yaml.load(f, Loader=yaml.Loader)
 
             user_dir = _cookiecutter_config_file.dirpath()
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -9,7 +9,7 @@ def test_config(testdir):
         """
         # -*- coding: utf-8 -*-
 
-        import poyo
+        import yaml
 
 
         def test_user_dir(tmpdir_factory, _cookiecutter_config_file):
@@ -24,8 +24,8 @@ def test_config(testdir):
 
 
         def test_valid_cookiecutter_config(_cookiecutter_config_file):
-            config_text = _cookiecutter_config_file.read()
-            config = poyo.parse_string(config_text)
+            with open(_cookiecutter_config_file) as f:            
+                config = yaml.load(f)
 
             user_dir = _cookiecutter_config_file.dirpath()
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -24,7 +24,7 @@ def test_config(testdir):
 
 
         def test_valid_cookiecutter_config(_cookiecutter_config_file):
-            with open(_cookiecutter_config_file) as f:         
+            with open(_cookiecutter_config_file) as f:
                 config = yaml.load(f, Loader=yaml.Loader)
 
             user_dir = _cookiecutter_config_file.dirpath()

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py{36,37,38,39}-pytest{3,4,5,6},flake8
+envlist = py{37,38,39,310}-pytest{4,5,6,7},flake8
 
 [testenv]
 deps =
-  pytest3: pytest>=3,<4
   pytest4: pytest>=4,<5
   pytest5: pytest>=5,<6
   pytest6: pytest>=6,<7
+  pytest7: pytest>=7,<8
 commands = pytest {posargs:tests}
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310}-pytest{4,5,6,7},flake8
+envlist = py{37,38,39,310,311}-pytest{4,5,6,7},flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
Dumps config as JSON (using built-in parser) since this can be read as YAML and it avoids adding any dependencies.

**Update**: Actually can depend on cookiecutter 2.1.0 and use PyYAML dumper.