### PR TITLE
Enable passing extra arguments to cookiecutter function

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -15,21 +15,21 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        environment: ["py37", "py38", "py39", "py310", "py311", "flake8"]
+        environment: ["py39", "py310", "py311", "py312", "py313", "flake8"]
 
         include:
-          - environment: "py37"
-            python: "3.7"
-          - environment: "py38"
-            python: "3.8"
           - environment: "py39"
             python: "3.9"
           - environment: "py310"
             python: "3.10"
           - environment: "py311"
             python: "3.11"
+          - environment: "py312"
+            python: "3.12"
+          - environment: "py313"
+            python: "3.13"
           - environment: "flake8"
-            python: "3.7"
+            python: "3.9"
 
     runs-on: ${{ matrix.os }}
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -31,8 +31,10 @@ def test_bake_project(cookies):
 It accepts the ``extra_context`` keyword argument that will be
 passed to cookiecutter. The given dictionary will override the default values
 of the template context, allowing you to test arbitrary user input data.
-
 Please see the [Injecting Extra Context] section of the
 official cookiecutter documentation.
+
+It also accepts extra keyword arguments,
+which are passed directly to the cookiecutter function.
 
   [Injecting Extra Context]: https://cookiecutter.readthedocs.io/en/latest/advanced/injecting_context.html#injecting-extra-context

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python",
         "Topic :: Software Development :: Testing",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setuptools.setup(
     name="pytest-cookies",
-    version="0.7.0",
+    version="0.8.0",
     author="Raphael Pierzina",
     author_email="raphael@hackebrot.de",
     maintainer="Raphael Pierzina",

--- a/src/pytest_cookies/plugin.py
+++ b/src/pytest_cookies/plugin.py
@@ -72,7 +72,7 @@ class Cookies(object):
         self._counter += 1
         return output_dir
 
-    def bake(self, extra_context=None, template=None):
+    def bake(self, extra_context=None, template=None, **extra_kwargs):
         exception = None
         exit_code = 0
         project_dir = None
@@ -99,6 +99,7 @@ class Cookies(object):
                 extra_context=extra_context,
                 output_dir=str(self._new_output_dir()),
                 config_file=str(self._config_file),
+                **extra_kwargs
             )
         except SystemExit as e:
             if e.code != 0:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}-pytest{4,5,6,7},flake8
+envlist = py{37,38,39,310,311,312,313}-pytest{4,5,6,7,8},flake8
 
 [testenv]
 deps =
@@ -7,6 +7,7 @@ deps =
   pytest5: pytest>=5,<6
   pytest6: pytest>=6,<7
   pytest7: pytest>=7,<8
+  pytest8: pytest>=8,<9
 commands = pytest {posargs:tests}
 
 [testenv:flake8]


### PR DESCRIPTION
Required to enable new functionality, such as multiple templates in the same repo (cia directory argument)